### PR TITLE
fix: fix Force Pads on ThinkBook G6/G7+

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libinput (1.26.0-1deepin2) UNRELEASED; urgency=medium
+
+  * Backport a patch to fix the "Force Pads" on ThinkBook 14+ G6/G7+.
+  * Ref: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1079
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Tue, 19 Nov 2024 10:24:27 +0800
+
 libinput (1.26.0-1deepin1) unstable; urgency=medium
 
   * Backport a patch to fix unreliable touchpad on HONOR MagicBook Art 14.

--- a/debian/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
+++ b/debian/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
@@ -1,0 +1,36 @@
+From 6258cef9b0b8157231606957477dc607ad9936cf Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 12 Nov 2024 11:29:27 +0800
+Subject: [PATCH 2/3] quirks: add pressure pad quirk for Lenovo ThinkBook 14
+ G7+ ASP
+
+Some Lenovo ThinkBook 14 G7+ ASP models ship with pressure pads (nominally
+"Force Pad"). However, they do not appear to be declared as such by the
+firmware.
+
+Add a quirk to make them work.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-lenovo.quirks | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/quirks/50-system-lenovo.quirks b/quirks/50-system-lenovo.quirks
+index 852eba01..15825426 100644
+--- a/quirks/50-system-lenovo.quirks
++++ b/quirks/50-system-lenovo.quirks
+@@ -376,3 +376,11 @@ MatchName=ITE Tech. Inc. ITE Device(8910) Keyboard
+ MatchUdevType=keyboard
+ MatchDMIModalias=dmi:*svnLENOVO:*
+ AttrKeyboardIntegration=internal
++
++# Some ThinkBook 14 G7+ ASP models come with pressure pads that were not
++# correctly declared as such.
++[Lenovo ThinkBook 14 G7+ ASP touchpad]
++MatchName=*GXTP5100*
++MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook14G7+ASP*:*
++MatchUdevType=touchpad
++ModelPressurePad=1
+-- 
+2.47.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 #placeholder
 tools-remove-references-to-libinput_quir.patch
 0001-quirks-add-a-quirk-for-the-HONOR-MagicBook-Art-14-to.patch
+0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch


### PR DESCRIPTION
Backport a patch to fix the "Force Pads" on ThinkBook 14+ G6/G7+.

Link: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1079